### PR TITLE
Put back the initial value after removing the location

### DIFF
--- a/editor/ProjectController.py
+++ b/editor/ProjectController.py
@@ -764,6 +764,8 @@ class ProjectController(ConfigTreeNode, PLCControler):
                 a = line.split("AT %")
                 b = a[1].split(":")
                 modified_program += a[0] + ":" + b[1]
+                if(len(b) > 2):
+                    modified_program += ":" + b[2]
             else:
                 modified_program += line
 


### PR DESCRIPTION
Thank you for a great piece of software!

I was having issues previewing my program in the editor when I tried setting initial values for a few registers. Reviewing the files it appears that the function `RemoveLocatedVariables` was not handling the initial values properly when it adjusted the PLC file.

I'm not sure if this is the best solution but by adding these two lines I was able to run my program with no issue.

Thanks again!