### PR TITLE
fixed desktop file in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -49,8 +49,9 @@ python2.7 ./editor/Beremiz.py" > openplc_editor.sh
 chmod +x ./openplc_editor.sh
 cd ~/.local/share/applications
 echo -e "[Desktop Entry]\n\
-Name=OpenPLC Editor v1.0\n\
+Name=OpenPLC Editor\n\
+Categories=Development;\n\
 Exec=\"$WORKING_DIR/openplc_editor.sh\"\n\
-Icon=\"$WORKING_DIR/editor/images/brz.ico\"\n\
+Icon=$WORKING_DIR/editor/images/brz.png\n\
 Type=Application\n\
 Terminal=false" > OpenPLC_Editor.desktop


### PR DESCRIPTION
I fixed the following issues in the desktop file:
- the name should not contain the version number (not interesting in the desktop menu, deprecates too fast)
- at least one category should be added (I added "Development")
- the entry "Icon" doesn't support quoting and completely fails to load the icon when used, therefore I had to removed it
- the PNG icon has a much better resolution so let's use it instead of the small and blurry ICO version