### PR TITLE
Optimize the algorithm of finding nearest connector and fix a bug that occurs when add a connector

### DIFF
--- a/editor/editors/Viewer.py
+++ b/editor/editors/Viewer.py
@@ -2668,6 +2668,7 @@ class Viewer(EditorPanel, DebugViewer):
             dialog = ConnectionDialog(self.ParentWindow, self.Controler, self.TagName)
             dialog.SetPreviewFont(self.GetFont())
             dialog.SetMinElementSize((bbox.width, bbox.height))
+            dialog.RefreshPreview()
             values = (dialog.GetValues()
                       if dialog.ShowModal() == wx.ID_OK
                       else None)

--- a/editor/graphics/GraphicCommons.py
+++ b/editor/graphics/GraphicCommons.py
@@ -293,16 +293,18 @@ class Graphic_Element(ToolTipProducer):
         return {}
 
     def FindNearestConnector(self, position, connectors):
-        distances = []
+        min_distance = None
+
         for connector in connectors:
             connector_pos = connector.GetRelPosition()
-            distances.append((sqrt((self.Pos.x + connector_pos.x - position.x) ** 2 +
-                                   (self.Pos.y + connector_pos.y - position.y) ** 2),
-                              connector))
-        distances.sort()
-        if len(distances) > 0:
-            return distances[0][1]
-        return None
+            dis = sqrt((self.Pos.x + connector_pos.x - position.x) ** 2 +
+                       (self.Pos.y + connector_pos.y - position.y) ** 2)
+
+            if min_distance is None or dis < min_distance[0]:
+                min_distance = (dis, connector)
+
+        return min_distance[1] if min_distance is not None else None
+
 
     def IsOfType(self, type, reference):
         return self.Parent.IsOfType(type, reference)


### PR DESCRIPTION
## Optimize the algorithm of finding nearest connector

I find there is an efficiency problem in function at file `GraphicCommons.py`. When there are too many connectors, sorting them is a waste of time. 

```python
    def FindNearestConnector(self, position, connectors):
        distances = []
        for connector in connectors:
            connector_pos = connector.GetRelPosition()
            distances.append((sqrt((self.Pos.x + connector_pos.x - position.x) ** 2 +
                                   (self.Pos.y + connector_pos.y - position.y) ** 2),
                              connector))
        distances.sort()
        if len(distances) > 0:
            return distances[0][1]
        return None
```

## fix a bug

when add a new connector there is an error:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/wx-3.0-gtk2/wx/_core.py", line 16765, in <lambda>
    lambda event: event.callable(*event.args, **event.kw) )
  File "/data/OpenPLC_Editor/editor/editors/Viewer.py", line 2672, in AddNewConnection
    if dialog.ShowModal() == wx.ID_OK
  File "/data/OpenPLC_Editor/editor/dialogs/ConnectionDialog.py", line 151, in GetValues
    values["width"], values["height"] = self.Element.GetSize()
AttributeError: 'NoneType' object has no attribute 'GetSize'
```
