### PR TITLE
Ugly FIX of Matplotlib private function import

### DIFF
--- a/editor/controls/DebugVariablePanel/DebugVariableGraphicViewer.py
+++ b/editor/controls/DebugVariablePanel/DebugVariableGraphicViewer.py
@@ -31,7 +31,9 @@ import wx
 import matplotlib
 import matplotlib.pyplot
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
-from matplotlib.backends.backend_wxagg import _convert_agg_to_wx_bitmap
+
+# TODO: Do this proper way! Do not use private functions from random libraries
+from matplotlib.backends.backend_wxagg import _rgba_to_wx_bitmap
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from mpl_toolkits.mplot3d import Axes3D
 
@@ -1360,7 +1362,8 @@ class DebugVariableGraphicViewer(DebugVariableViewer, FigureCanvas):
         FigureCanvasAgg.draw(self)
 
         # Get bitmap of figure rendered
-        self.bitmap = _convert_agg_to_wx_bitmap(self.get_renderer(), None)
+        # TODO: Do this proper way! Do not use private functions from random libraries
+        self.bitmap = _rgba_to_wx_bitmap(self.get_renderer().buffer_rgba())
         if wx.VERSION < (3, 0, 0):
             self.bitmap.UseAlpha()
 

--- a/editor/controls/DebugVariablePanel/DebugVariableViewer.py
+++ b/editor/controls/DebugVariablePanel/DebugVariableViewer.py
@@ -29,7 +29,9 @@ from collections import OrderedDict
 from functools import reduce
 
 import wx
-from matplotlib.backends.backend_wxagg import _convert_agg_to_wx_bitmap
+
+# TODO: Do this proper way! Do not use private functions from random libraries
+from matplotlib.backends.backend_wxagg import _rgba_to_wx_bitmap
 
 from dialogs.ForceVariableDialog import ForceVariableDialog
 
@@ -303,8 +305,9 @@ class DebugVariableViewer(object):
                 srcX = srcBBox.x - (srcPos.x if destBBox.x == 0 else 0)
                 srcY = srcBBox.y - (srcPos.y if destBBox.y == 0 else 0)
 
-                srcBmp = _convert_agg_to_wx_bitmap(
-                    srcPanel.get_renderer(), None)
+                # TODO: Do this proper way! Do not use private functions from random libraries
+                srcBmp = _rgba_to_wx_bitmap(
+                    srcPanel.get_renderer().buffer_rgba())
                 srcDC = wx.MemoryDC()
                 srcDC.SelectObject(srcBmp)
 


### PR DESCRIPTION
Since matplotlib changed private functions (that is why never use shortcuts like that). We have to change to new function. It is still ugly fix as it can change in next version again. But atleast it will start up now... Better will be use public functions/classes. But unfortunately I do not understand whole concept, so I can not do better than this for now.

Fixes #62 