### PR TITLE
Fixfloat

### DIFF
--- a/editor/controls/LogViewer.py
+++ b/editor/controls/LogViewer.py
@@ -40,6 +40,13 @@ THUMB_SIZE_RATIO = 1. / 8.
 
 
 def ArrowPoints(direction, width, height, xoffset, yoffset):
+    if type(width) is float or type(height) is float or type(xoffset) is float or type(yoffset) is float:
+        print("WARNING: ArrowPoints: some of input is float")
+        width = int(width)
+        height = int(height)
+        xoffset = int(xoffset)
+        yoffset = int(yoffset)
+
     if direction == wx.TOP:
         return [wx.Point(xoffset + 1, yoffset + height - 2),
                 wx.Point(xoffset + width // 2, yoffset + 1),

--- a/editor/controls/ProjectPropertiesPanel.py
+++ b/editor/controls/ProjectPropertiesPanel.py
@@ -257,8 +257,8 @@ class ProjectPropertiesPanel(wx.Notebook):
             elif item == "scaling":
                 for language, (x, y) in list(value.items()):
                     if language in self.Scalings:
-                        self.Scalings[language][0].SetValue(x)
-                        self.Scalings[language][1].SetValue(y)
+                        self.Scalings[language][0].SetValue(int(x))
+                        self.Scalings[language][1].SetValue(int(y))
             else:
                 tc = getattr(self, item, None)
                 if tc is not None:

--- a/editor/editors/Viewer.py
+++ b/editor/editors/Viewer.py
@@ -1369,7 +1369,7 @@ class Viewer(EditorPanel, DebugViewer):
         element.SetPosition(instance.x, instance.y)
         element.SetSize(instance.width, instance.height)
         for i, output_connector in enumerate(instance.outputs):
-            connector_pos = wx.Point(*output_connector.position)
+            connector_pos = wx.Point(int(output_connector.position.x), int(output_connector.position.y))
             if isinstance(element, FBD_Block):
                 connector = element.GetConnector(connector_pos,
                                                  output_name=output_connector.name)
@@ -1385,7 +1385,7 @@ class Viewer(EditorPanel, DebugViewer):
                 if connectors["outputs"].index(connector) == i:
                     connector.SetPosition(connector_pos)
         for i, input_connector in enumerate(instance.inputs):
-            connector_pos = wx.Point(*input_connector.position)
+            connector_pos = wx.Point(int(input_connector.position.x), int(input_connector.position.y))
             if isinstance(element, FBD_Block):
                 connector = element.GetConnector(connector_pos,
                                                  input_name=input_connector.name)
@@ -1426,7 +1426,7 @@ class Viewer(EditorPanel, DebugViewer):
 
             points = link.points
             end_connector = connected.GetConnector(
-                wx.Point(points[-1].x, points[-1].y)
+                wx.Point(int(points[-1].x), int(points[-1].y))
                 if len(points) > 0 else wx.Point(0, 0),
                 link.formalParameter)
             if end_connector is not None:

--- a/editor/editors/Viewer.py
+++ b/editor/editors/Viewer.py
@@ -243,8 +243,8 @@ class ViewerDropTarget(wx.TextDropTarget):
         tagname = self.ParentWindow.GetTagName()
         pou_name, pou_type = self.ParentWindow.Controler.GetEditedElementType(tagname, self.ParentWindow.Debug)
         x, y = self.ParentWindow.CalcUnscrolledPosition(x, y)
-        x = int(x / self.ParentWindow.ViewScale[0])
-        y = int(y / self.ParentWindow.ViewScale[1])
+        x = x // self.ParentWindow.ViewScale[0]
+        y = y // self.ParentWindow.ViewScale[1]
         scaling = self.ParentWindow.Scaling
         message = None
         try:
@@ -284,10 +284,10 @@ class ViewerDropTarget(wx.TextDropTarget):
                         block = FBD_Block(self.ParentWindow, values[0], blockname, id, inputs=blockinputs)
                         width, height = block.GetMinSize()
                         if scaling is not None:
-                            x = round(x / scaling[0]) * scaling[0]
-                            y = round(y / scaling[1]) * scaling[1]
-                            width = round(width / scaling[0] + 0.5) * scaling[0]
-                            height = round(height / scaling[1] + 0.5) * scaling[1]
+                            x = int(round(x / scaling[0]) * scaling[0])
+                            y = int(round(y / scaling[1]) * scaling[1])
+                            width = int(round(width / scaling[0] + 0.5) * scaling[0])
+                            height = int(round(height / scaling[1] + 0.5) * scaling[1])
                         block.SetPosition(x, y)
                         block.SetSize(width, height)
                         self.ParentWindow.AddBlock(block)
@@ -715,7 +715,7 @@ class Viewer(EditorPanel, DebugViewer):
             faces["size"] -= 1
         self.Editor.SetFont(font)
         self.MiniTextDC = wx.MemoryDC(wx.Bitmap(1, 1))
-        self.MiniTextDC.SetFont(wx.Font(faces["size"] * 0.75, wx.SWISS, wx.NORMAL, wx.NORMAL, faceName=faces["helv"]))
+        self.MiniTextDC.SetFont(wx.Font(faces["size"], wx.SWISS, wx.NORMAL, wx.NORMAL, faceName=faces["helv"]))
 
         self.CurrentScale = None
         self.SetScale(ZOOM_FACTORS.index(1.0), False)

--- a/editor/graphics/GraphicCommons.py
+++ b/editor/graphics/GraphicCommons.py
@@ -1643,7 +1643,7 @@ class Wire(Graphic_Element, DebugDataConsumer):
         end_connector = connectors.get(self.EndConnected, None)
         if start_connector is not None and end_connector is not None:
             wire = Wire(parent)
-            wire.SetPoints([(point.x + dx, point.y + dy) for point in self.Points])
+            wire.SetPoints([(int(point.x + dx), int(point.y + dy)) for point in self.Points])
             start_connector.Connect((wire, 0), False)
             end_connector.Connect((wire, -1), False)
             wire.ConnectStartPoint(start_connector.GetPosition(), start_connector)
@@ -1937,8 +1937,8 @@ class Wire(Graphic_Element, DebugDataConsumer):
             else:
                 x2, y2 = self.Points[i + 1].x, self.Points[i + 1].y
             # Calculate a rectangle around the segment
-            rect = wx.Rect(min(x1, x2) - ANCHOR_DISTANCE, min(y1, y2) - ANCHOR_DISTANCE,
-                           abs(x1 - x2) + 2 * ANCHOR_DISTANCE, abs(y1 - y2) + 2 * ANCHOR_DISTANCE)
+            rect = wx.Rect(int(min(x1, x2) - ANCHOR_DISTANCE), int(min(y1, y2) - ANCHOR_DISTANCE),
+                           int(abs(x1 - x2) + 2 * ANCHOR_DISTANCE), int(abs(y1 - y2) + 2 * ANCHOR_DISTANCE))
             test |= rect.Contains(pt.x, pt.y)
         return test
 
@@ -1979,6 +1979,11 @@ class Wire(Graphic_Element, DebugDataConsumer):
             self.Points = []
             lx, ly = None, None
             for x, y in points:
+                if type(x) is float or type(y) is float:
+                    print("WARNING: SetPoints: position is in float instead int")
+                    x = int(x)
+                    y = int(y)
+
                 ex, ey = lx == x, ly == y
                 if ex and ey:
                     # duplicate
@@ -1993,10 +1998,10 @@ class Wire(Graphic_Element, DebugDataConsumer):
             self.StartPoint = [None, vector(self.Points[0], self.Points[1])]
             self.EndPoint = [None, vector(self.Points[-1], self.Points[-2])]
             # Calculate the start and end points
-            self.StartPoint[0] = wx.Point(self.Points[0].x + CONNECTOR_SIZE * self.StartPoint[1][0],
-                                          self.Points[0].y + CONNECTOR_SIZE * self.StartPoint[1][1])
-            self.EndPoint[0] = wx.Point(self.Points[-1].x + CONNECTOR_SIZE * self.EndPoint[1][0],
-                                        self.Points[-1].y + CONNECTOR_SIZE * self.EndPoint[1][1])
+            self.StartPoint[0] = wx.Point(int(self.Points[0].x + CONNECTOR_SIZE * self.StartPoint[1][0]),
+                                          int(self.Points[0].y + CONNECTOR_SIZE * self.StartPoint[1][1]))
+            self.EndPoint[0] = wx.Point(int(self.Points[-1].x + CONNECTOR_SIZE * self.EndPoint[1][0]),
+                                        int(self.Points[-1].y + CONNECTOR_SIZE * self.EndPoint[1][1]))
             self.Points[0] = self.StartPoint[0]
             self.Points[-1] = self.EndPoint[0]
             # Calculate the segments directions
@@ -2041,10 +2046,10 @@ class Wire(Graphic_Element, DebugDataConsumer):
     # Returns a list of the position of all wire points
     def GetPoints(self, invert=False):
         points = self.VerifyPoints()
-        points[0] = wx.Point(points[0].x - CONNECTOR_SIZE * self.StartPoint[1][0],
-                             points[0].y - CONNECTOR_SIZE * self.StartPoint[1][1])
-        points[-1] = wx.Point(points[-1].x - CONNECTOR_SIZE * self.EndPoint[1][0],
-                              points[-1].y - CONNECTOR_SIZE * self.EndPoint[1][1])
+        points[0] = wx.Point(int(points[0].x - CONNECTOR_SIZE * self.StartPoint[1][0]),
+                             int(points[0].y - CONNECTOR_SIZE * self.StartPoint[1][1]))
+        points[-1] = wx.Point(int(points[-1].x - CONNECTOR_SIZE * self.EndPoint[1][0]),
+                              int(points[-1].y - CONNECTOR_SIZE * self.EndPoint[1][1]))
         # An inversion of the list is asked
         if invert:
             points.reverse()
@@ -2083,10 +2088,10 @@ class Wire(Graphic_Element, DebugDataConsumer):
     def GeneratePoints(self, realpoints=True):
         i = 0
         # Calculate the start enad end points with the minimum segment size in the right direction
-        end = wx.Point(self.EndPoint[0].x + self.EndPoint[1][0] * MIN_SEGMENT_SIZE,
-                       self.EndPoint[0].y + self.EndPoint[1][1] * MIN_SEGMENT_SIZE)
-        start = wx.Point(self.StartPoint[0].x + self.StartPoint[1][0] * MIN_SEGMENT_SIZE,
-                         self.StartPoint[0].y + self.StartPoint[1][1] * MIN_SEGMENT_SIZE)
+        end = wx.Point(int(self.EndPoint[0].x + self.EndPoint[1][0] * MIN_SEGMENT_SIZE),
+                       int(self.EndPoint[0].y + self.EndPoint[1][1] * MIN_SEGMENT_SIZE))
+        start = wx.Point(int(self.StartPoint[0].x + self.StartPoint[1][0] * MIN_SEGMENT_SIZE),
+                         int(self.StartPoint[0].y + self.StartPoint[1][1] * MIN_SEGMENT_SIZE))
         # Evaluate the point till it's the last
         while i < len(self.Points) - 1:
             # The next point is the last
@@ -2684,18 +2689,18 @@ class Wire(Graphic_Element, DebugDataConsumer):
         dc.SetLogicalFunction(wx.AND)
         # Draw the start and end points if they are not connected or the mouse is over them
         if len(self.Points) > 0 and (not self.StartConnected or self.OverStart):
-            dc.DrawCircle(round(self.Points[0].x * scalex),
-                          round(self.Points[0].y * scaley),
-                          (POINT_RADIUS + 1) * scalex + 2)
+            dc.DrawCircle(int(round(self.Points[0].x * scalex)),
+                          int(round(self.Points[0].y * scaley)),
+                          int((POINT_RADIUS + 1) * scalex + 2))
         if len(self.Points) > 1 and (not self.EndConnected or self.OverEnd):
-            dc.DrawCircle(self.Points[-1].x * scalex, self.Points[-1].y * scaley, (POINT_RADIUS + 1) * scalex + 2)
+            dc.DrawCircle(int(self.Points[-1].x * scalex), int(self.Points[-1].y * scaley), int((POINT_RADIUS + 1) * scalex + 2))
         # Draw the wire lines and the last point (it seems that DrawLines stop before the last point)
         if len(self.Points) > 1:
-            points = [wx.Point(round((self.Points[0].x - self.Segments[0][0]) * scalex),
-                               round((self.Points[0].y - self.Segments[0][1]) * scaley))]
-            points.extend([wx.Point(round(point.x * scalex), round(point.y * scaley)) for point in self.Points[1:-1]])
-            points.append(wx.Point(round((self.Points[-1].x + self.Segments[-1][0]) * scalex),
-                                   round((self.Points[-1].y + self.Segments[-1][1]) * scaley)))
+            points = [wx.Point(int(round((self.Points[0].x - self.Segments[0][0]) * scalex)),
+                               int(round((self.Points[0].y - self.Segments[0][1]) * scaley)))]
+            points.extend([wx.Point(int(round(point.x * scalex)), int(round(point.y * scaley))) for point in self.Points[1:-1]])
+            points.append(wx.Point(int(round((self.Points[-1].x + self.Segments[-1][0]) * scalex)),
+                                   int(round((self.Points[-1].y + self.Segments[-1][1]) * scaley))))
         else:
             points = []
         dc.DrawLines(points)
@@ -2738,9 +2743,9 @@ class Wire(Graphic_Element, DebugDataConsumer):
             dc.DrawCircle(self.Points[-1].x, self.Points[-1].y, POINT_RADIUS)
         # Draw the wire lines and the last point (it seems that DrawLines stop before the last point)
         if len(self.Points) > 1:
-            points = [wx.Point(self.Points[0].x - self.Segments[0][0], self.Points[0].y - self.Segments[0][1])]
+            points = [wx.Point(int(self.Points[0].x - self.Segments[0][0]), int(self.Points[0].y - self.Segments[0][1]))]
             points.extend([point for point in self.Points[1:-1]])
-            points.append(wx.Point(self.Points[-1].x + self.Segments[-1][0], self.Points[-1].y + self.Segments[-1][1]))
+            points.append(wx.Point(int(self.Points[-1].x + self.Segments[-1][0]), int(self.Points[-1].y + self.Segments[-1][1])))
         else:
             points = []
         dc.DrawLines(points)

--- a/editor/graphics/GraphicCommons.py
+++ b/editor/graphics/GraphicCommons.py
@@ -183,8 +183,8 @@ def GetScaledEventPosition(event, dc, scaling):
     """
     pos = event.GetLogicalPosition(dc)
     if scaling:
-        pos.x = round(pos.x / scaling[0]) * scaling[0]
-        pos.y = round(pos.y / scaling[1]) * scaling[1]
+        pos.x = int(round(pos.x / scaling[0]) * scaling[0])
+        pos.y = int(round(pos.y / scaling[1]) * scaling[1])
     return pos
 
 
@@ -314,6 +314,11 @@ class Graphic_Element(ToolTipProducer):
 
     # Changes the block position
     def SetPosition(self, x, y):
+        # TODO: FIX this at source of float, here it is just workaround
+        if type(x) is float or type(y) is float:
+            print("WARNING: position is float instead int")
+            x = int(x)
+            y = int(y)
         self.Pos.x = x
         self.Pos.y = y
         self.RefreshConnected()
@@ -325,6 +330,12 @@ class Graphic_Element(ToolTipProducer):
 
     # Changes the element size
     def SetSize(self, width, height):
+        # TODO: FIX this at source of float, here it is just workaround
+        if type(width) is float or type(height) is float:
+            print("WARNING: size is float instead int")
+            width = int(width)
+            height = int(height)
+
         self.Size.SetWidth(width)
         self.Size.SetHeight(height)
         self.RefreshConnectors()
@@ -431,13 +442,13 @@ class Graphic_Element(ToolTipProducer):
         pos = event.GetPosition()
         pt = wx.Point(*self.Parent.CalcUnscrolledPosition(pos.x, pos.y))
 
-        left = (self.BoundingBox.x - 2) * scalex - HANDLE_SIZE
+        left = int((self.BoundingBox.x - 2) * scalex - HANDLE_SIZE)
         center = (self.BoundingBox.x + self.BoundingBox.width // 2) * scalex - HANDLE_SIZE // 2
-        right = (self.BoundingBox.x + self.BoundingBox.width + 2) * scalex
+        right = int((self.BoundingBox.x + self.BoundingBox.width + 2) * scalex)
 
-        top = (self.BoundingBox.y - 2) * scaley - HANDLE_SIZE
+        top = int((self.BoundingBox.y - 2) * scaley - HANDLE_SIZE)
         middle = (self.BoundingBox.y + self.BoundingBox.height / 2) * scaley - HANDLE_SIZE // 2
-        bottom = (self.BoundingBox.y + self.BoundingBox.height + 2) * scaley
+        bottom = int((self.BoundingBox.y + self.BoundingBox.height + 2) * scaley)
 
         extern_rect = wx.Rect(left, top, right + HANDLE_SIZE - left, bottom + HANDLE_SIZE - top)
         intern_rect = wx.Rect(left + HANDLE_SIZE, top + HANDLE_SIZE, right - left - HANDLE_SIZE, bottom - top - HANDLE_SIZE)
@@ -679,13 +690,13 @@ class Graphic_Element(ToolTipProducer):
                 dc.SetPen(MiterPen(wx.BLACK))
                 dc.SetBrush(wx.BLACK_BRUSH)
 
-                left = (self.BoundingBox.x - 2) * scalex - HANDLE_SIZE
+                left = int((self.BoundingBox.x - 2) * scalex - HANDLE_SIZE)
                 center = (self.BoundingBox.x + self.BoundingBox.width // 2) * scalex - HANDLE_SIZE // 2
-                right = (self.BoundingBox.x + self.BoundingBox.width + 2) * scalex
+                right = int((self.BoundingBox.x + self.BoundingBox.width + 2) * scalex)
 
-                top = (self.BoundingBox.y - 2) * scaley - HANDLE_SIZE
+                top = int((self.BoundingBox.y - 2) * scaley - HANDLE_SIZE)
                 middle = (self.BoundingBox.y + self.BoundingBox.height // 2) * scaley - HANDLE_SIZE // 2
-                bottom = (self.BoundingBox.y + self.BoundingBox.height + 2) * scaley
+                bottom = int((self.BoundingBox.y + self.BoundingBox.height + 2) * scaley)
 
                 for x, y in [(left, top), (center, top), (right, top),
                              (left, middle), (right, middle),

--- a/editor/graphics/GraphicCommons.py
+++ b/editor/graphics/GraphicCommons.py
@@ -201,6 +201,10 @@ def DirectionChoice(v_base, v_target, dir_target):
 
 
 def MiterPen(colour, width=1, style=wx.SOLID):
+    if type(width) is float:
+        print("WARNING: MiterPen: width is in float instead int")
+        width = int(width)
+
     pen = wx.Pen(colour, width, style)
     pen.SetJoin(wx.JOIN_MITER)
     pen.SetCap(wx.CAP_PROJECTING)
@@ -691,11 +695,11 @@ class Graphic_Element(ToolTipProducer):
                 dc.SetBrush(wx.BLACK_BRUSH)
 
                 left = int((self.BoundingBox.x - 2) * scalex - HANDLE_SIZE)
-                center = (self.BoundingBox.x + self.BoundingBox.width // 2) * scalex - HANDLE_SIZE // 2
+                center = int((self.BoundingBox.x + self.BoundingBox.width // 2) * scalex - HANDLE_SIZE // 2)
                 right = int((self.BoundingBox.x + self.BoundingBox.width + 2) * scalex)
 
                 top = int((self.BoundingBox.y - 2) * scaley - HANDLE_SIZE)
-                middle = (self.BoundingBox.y + self.BoundingBox.height // 2) * scaley - HANDLE_SIZE // 2
+                middle = int((self.BoundingBox.y + self.BoundingBox.height // 2) * scaley - HANDLE_SIZE // 2)
                 bottom = int((self.BoundingBox.y + self.BoundingBox.height + 2) * scaley)
 
                 for x, y in [(left, top), (center, top), (right, top),

--- a/editor/graphics/LD_Objects.py
+++ b/editor/graphics/LD_Objects.py
@@ -545,7 +545,7 @@ class LD_Contact(Graphic_Element, DebugDataConsumer):
         scaling = self.Parent.GetScaling()
         position = self.Size[1] // 2 + 1
         if scaling is not None:
-            position = round((self.Pos.y + position) / scaling[1]) * scaling[1] - self.Pos.y
+            position = int(round((self.Pos.y + position) / scaling[1]) * scaling[1] - self.Pos.y)
         self.Input.SetPosition(wx.Point(0, position))
         self.Output.SetPosition(wx.Point(self.Size[0], position))
         self.RefreshConnected()
@@ -593,11 +593,11 @@ class LD_Contact(Graphic_Element, DebugDataConsumer):
         dc.SetBrush(wx.Brush(HIGHLIGHTCOLOR))
         dc.SetLogicalFunction(wx.AND)
         # Draw two rectangles for representing the contact
-        left_left = (self.Pos.x - 1) * scalex - 2
-        right_left = (self.Pos.x + self.Size[0] - 2) * scalex - 2
-        top = (self.Pos.y - 1) * scaley - 2
-        width = 4 * scalex + 5
-        height = (self.Size[1] + 3) * scaley + 5
+        left_left = int((self.Pos.x - 1) * scalex - 2)
+        right_left = int((self.Pos.x + self.Size[0] - 2) * scalex - 2)
+        top = int((self.Pos.y - 1) * scaley - 2)
+        width = int(4 * scalex + 5)
+        height = int((self.Size[1] + 3) * scaley + 5)
 
         dc.DrawRectangle(left_left, top, width, height)
         dc.DrawRectangle(right_left, top, width, height)
@@ -865,7 +865,7 @@ class LD_Coil(Graphic_Element):
         scaling = self.Parent.GetScaling()
         position = self.Size[1] // 2 + 1
         if scaling is not None:
-            position = round((self.Pos.y + position) / scaling[1]) * scaling[1] - self.Pos.y
+            position = int(round((self.Pos.y + position) / scaling[1]) * scaling[1] - self.Pos.y)
         self.Input.SetPosition(wx.Point(0, position))
         self.Output.SetPosition(wx.Point(self.Size[0], position))
         self.RefreshConnected()

--- a/editor/graphics/LD_Objects.py
+++ b/editor/graphics/LD_Objects.py
@@ -191,7 +191,7 @@ class LD_PowerRail(Graphic_Element):
             else:
                 position = self.Extensions[0] + int(round(i * interval))
             if scaling is not None:
-                position = round((self.Pos.y + position) / scaling[1]) * scaling[1] - self.Pos.y
+                position = int(round((self.Pos.y + position) / scaling[1]) * scaling[1] - self.Pos.y)
             if self.Type == LEFTRAIL:
                 connector.SetPosition(wx.Point(self.Size[0], position))
             elif self.Type == RIGHTRAIL:

--- a/editor/graphics/RubberBand.py
+++ b/editor/graphics/RubberBand.py
@@ -164,8 +164,8 @@ class RubberBand(object):
         for bbox in bboxes:
             if bbox is not None:
                 dc.DrawRectangle(
-                    bbox.x * scalex, bbox.y * scaley,
-                    bbox.width * scalex, bbox.height * scaley)
+                    int(bbox.x * scalex), int(bbox.y * scaley),
+                    int(bbox.width * scalex), int(bbox.height * scaley))
 
         dc.SetLogicalFunction(wx.COPY)
 


### PR DESCRIPTION
By WX documentation SetValue of SpinCtrl want int or text (https://docs.wxpython.org/wx.SpinCtrl.html#wx.SpinCtrl.SetValue) but x/y are float. So let's cast them to integer.

It causes this bug

```
Traceback (most recent call last):
  File "/home/petrkr/svn/OpenPLC_Editor/editor/IDEFrame.py", line 1442, in OnPouSelectedChanged
    window.RefreshView()
  File "/home/petrkr/svn/OpenPLC_Editor/editor/editors/ProjectNodeEditor.py", line 85, in RefreshView
    self.ProjectProperties.RefreshView()
  File "/home/petrkr/svn/OpenPLC_Editor/editor/controls/ProjectPropertiesPanel.py", line 245, in RefreshView
    self.SetValues(self.Controller.GetProjectProperties())
  File "/home/petrkr/svn/OpenPLC_Editor/editor/controls/ProjectPropertiesPanel.py", line 262, in SetValues
    self.Scalings[language][0].SetValue(x)
TypeError: SpinCtrl.SetValue(): arguments did not match any overloaded call:
  overload 1: argument 1 has unexpected type 'float'
  overload 2: argument 1 has unexpected type 'float'
```