### PR TITLE
Add com port descriptions to Arduino Upload dialog

### DIFF
--- a/editor/dialogs/ArduinoUploadDialog.py
+++ b/editor/dialogs/ArduinoUploadDialog.py
@@ -77,9 +77,10 @@ class ArduinoUploadDialog(wx.Dialog):
         self.m_staticText2.Wrap( -1 )
         fgSizer1.Add( self.m_staticText2, 0, wx.ALIGN_CENTER|wx.ALIGN_TOP|wx.BOTTOM|wx.LEFT, 15 )
 
-        com_port_comboChoices = [comport.device for comport in serial.tools.list_ports.comports()]
-        self.com_port_combo = wx.ComboBox( self.m_panel5, wx.ID_ANY, u"COM1", wx.DefaultPosition, wx.Size( 420,-1 ), com_port_comboChoices, 0 )
+        self.com_port_combo = wx.ComboBox( self.m_panel5, wx.ID_ANY, u"COM1", wx.DefaultPosition, wx.Size( 420,-1 ), [""], 0 )
+        self.reloadComboChoices() # Initialize the com port combo box
         fgSizer1.Add( self.com_port_combo, 0, wx.ALIGN_CENTER|wx.BOTTOM|wx.EXPAND, 15 )
+        self.com_port_combo.Bind(wx.EVT_COMBOBOX_DROPDOWN, self.reloadComboChoices)
 
 
         bSizer21.Add( fgSizer1, 1, wx.EXPAND, 5 )
@@ -412,6 +413,11 @@ class ArduinoUploadDialog(wx.Dialog):
     def __del__( self ):
         pass
 
+    def reloadComboChoices(self):
+        self.com_port_combo.Clear()
+        self.com_port_combo_choices = {comport.description:comport.device for comport in serial.tools.list_ports.comports()}
+        self.com_port_combo.SetItems(self.com_port_combo_choices.keys())
+
     def onUIChange(self, e):
         if (self.check_modbus_serial.GetValue() == False):
             self.serial_iface_combo.Enable(False)
@@ -463,7 +469,7 @@ class ArduinoUploadDialog(wx.Dialog):
         
         self.generateDefinitionsFile()
 
-        port = self.com_port_combo.GetValue()
+        port = self.com_port_combo_choices[str(self.com_port_combo.GetValue())] 
         if (self.check_compile.GetValue() == True):
             port = None
         


### PR DESCRIPTION
Adds device description alongside COM port numbers on the Arduino Upload dialog page

![image](https://user-images.githubusercontent.com/45793216/227353254-dbfdf617-eec9-493e-b466-ae363116845d.png)

I attempted to get it to refresh whenever the combo is opened, but I didn't have any luck getting the list to refresh after being created. Any advice on that is appreciated!
