### PR TITLE
make sure that $HOME/.local/share/applications exists before using it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,9 @@ then\n\
 fi\n\
 python2.7 ./editor/Beremiz.py" > openplc_editor.sh
 chmod +x ./openplc_editor.sh
-cd ~/.local/share/applications
+APP_DIR="$HOME/.local/share/applications"
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
 echo -e "[Desktop Entry]\n\
 Name=OpenPLC Editor\n\
 Categories=Development;\n\


### PR DESCRIPTION
The path $HOME/.local/share/applications is not always already existing.
To prevent installation errors (as happened on the laptops of my students) the install script should make sure that the path really exists before using it.