### PR TITLE
Update esp32.cpp

### DIFF
--- a/editor/arduino/src/hal/esp32.cpp
+++ b/editor/arduino/src/hal/esp32.cpp
@@ -5,6 +5,14 @@ extern "C" {
 #include "Arduino.h"
 #include "../examples/Baremetal/defines.h"
 
+#if defined(__SAM3X8E__) || defined(__SAMD21G18A__)
+    #include "SAMD_PWM.h"
+#elif defined(ESP32) || defined(__ESP32__)
+    #include "ESP32_FastPWM.h"
+#else
+    #include "AVR_PWM.h"
+#endif
+
 //OpenPLC HAL for ESP32 boards
 
 /******************PINOUT CONFIGURATION**************************
@@ -21,6 +29,44 @@ uint8_t pinMask_DIN[] = {PINMASK_DIN};
 uint8_t pinMask_AIN[] = {PINMASK_AIN};
 uint8_t pinMask_DOUT[] = {PINMASK_DOUT};
 uint8_t pinMask_AOUT[] = {PINMASK_AOUT};
+
+#define PWM_DEFAULT_FREQ      490
+#define PWM_CHANNEL_0_PIN     9
+#define PWM_CHANNEL_1_PIN     10
+
+#ifdef __AVR_ATmega32U4__
+    #define NUM_OF_PWM_PINS       2
+#elif defined(ESP32) || defined(__ESP32__)
+    #define NUM_OF_PWM_PINS       2
+    #define PWM_CHANNEL_0_PIN     32
+    #define PWM_CHANNEL_1_PIN     33
+	
+#else
+    #define NUM_OF_PWM_PINS       3
+    #define PWM_CHANNEL_2_PIN     11
+#endif
+
+
+#if defined(__SAM3X8E__) || defined(__SAMD21G18A__)
+    SAMD_PWM *PWM_Instance[NUM_OF_PWM_PINS];
+#elif defined(ESP32) || defined(__ESP32__)
+    ESP32_FAST_PWM *PWM_Instance[NUM_OF_PWM_PINS];
+#else
+    AVR_PWM *PWM_Instance[NUM_OF_PWM_PINS];
+#endif
+
+
+    #ifdef __AVR_ATmega32U4__
+        const uint8_t pins[] = {PWM_CHANNEL_0_PIN, PWM_CHANNEL_1_PIN};
+	#elif defined(ESP32) || defined(__ESP32__)		
+	    const uint8_t pins[] = {PWM_CHANNEL_0_PIN, PWM_CHANNEL_1_PIN};	
+    #else
+	const uint8_t pins[] = {PWM_CHANNEL_0_PIN, PWM_CHANNEL_1_PIN, PWM_CHANNEL_2_PIN};
+    #endif
+
+extern "C" uint8_t set_hardware_pwm(uint8_t, float, float); //this call is required for the C-based PWM block on the Editor
+
+bool pwm_initialized = false;
 
 void hardwareInit()
 {
@@ -43,6 +89,68 @@ void hardwareInit()
     {
         pinMode(pinMask_AOUT[i], OUTPUT);
     }
+}
+
+void init_pwm()
+{
+    // If PWM_CONTROLLER block is being used, disable pins from regular analogWrite
+
+    
+    for (int i = 0; i < NUM_ANALOG_OUTPUT; i++)
+    {
+        for (int j = 0; j < NUM_OF_PWM_PINS; j++)
+        {
+            if (pinMask_AOUT[i] == pins[j])
+            {
+                pinMask_AOUT[i] = 255; //disable pin
+            }
+        }
+    }
+
+    // Initialize PWM pins
+    #if defined(__SAM3X8E__) || defined(__SAMD21G18A__)
+        PWM_Instance[0] = new SAMD_PWM(PWM_CHANNEL_0_PIN, PWM_DEFAULT_FREQ, 0);
+        PWM_Instance[1] = new SAMD_PWM(PWM_CHANNEL_1_PIN, PWM_DEFAULT_FREQ, 0);
+		PWM_Instance[2] = new SAMD_PWM(PWM_CHANNEL_2_PIN, PWM_DEFAULT_FREQ, 0);
+	#elif defined(__AVR_ATmega32U4__)
+        PWM_Instance[0] = new AVR_PWM(PWM_CHANNEL_0_PIN, PWM_DEFAULT_FREQ, 0);
+        PWM_Instance[1] = new AVR_PWM(PWM_CHANNEL_1_PIN, PWM_DEFAULT_FREQ, 0);
+	#elif defined(ESP32) || defined(__ESP32__)
+		PWM_Instance[0] = new ESP32_FAST_PWM(PWM_CHANNEL_0_PIN, PWM_DEFAULT_FREQ, 0, 0); //ESP32_FAST_PWM needs different "Timer Groups" for different frequencys. see ESP32_FAST_PWM docu.
+		PWM_Instance[1] = new ESP32_FAST_PWM(PWM_CHANNEL_1_PIN, PWM_DEFAULT_FREQ, 0, 2); //ESP32_FAST_PWM needs different "Timer Groups" for different frequencys. see ESP32_FAST_PWM docu.
+	#else
+		PWM_Instance[0] = new AVR_PWM(PWM_CHANNEL_0_PIN, PWM_DEFAULT_FREQ, 0);
+		PWM_Instance[1] = new AVR_PWM(PWM_CHANNEL_1_PIN, PWM_DEFAULT_FREQ, 0);
+		PWM_Instance[2] = new AVR_PWM(PWM_CHANNEL_2_PIN, PWM_DEFAULT_FREQ, 0);
+	#endif
+}
+
+uint8_t set_hardware_pwm(uint8_t ch, float freq, float duty)
+{
+	
+	     Serial.println(ch); 
+         Serial.println(freq); 
+         Serial.println(duty);
+
+	
+    if (pwm_initialized == false)
+    {
+        init_pwm();
+        pwm_initialized = true;
+    }
+
+
+    if (ch >= NUM_OF_PWM_PINS)
+    {
+        return 0;
+    }
+	
+    if (PWM_Instance[ch]->setPWM(pins[ch], freq, duty))
+    {
+        return 1;
+    }
+
+    return 0;
 }
 
 void updateInputBuffers()


### PR DESCRIPTION
Added two possible PWM pins for the PWM_CONTROLLER function block (for now).

Tested on a ESP32 WROOM (devkit v1) board.

Used uno_leonardo_nano_micro_zero.cpp as a template.

Can the board/library selection somehow be globally outside of the HAL-files?
I mean the _if defined(__ESP32__)_... macro thingys.
That would shrink the code inside the Hal files....