### PR TITLE
Fixed issue where tray icon on linux would be pixelated image

### DIFF
--- a/editor/BeremizIDE.py
+++ b/editor/BeremizIDE.py
@@ -456,7 +456,10 @@ class Beremiz(IDEFrame, LocalRuntimeMixin):
     def __init__(self, parent, projectOpen=None, buildpath=None, ctr=None, debug=True, logf=None):
 
         # Add beremiz's icon in top left corner of the frame
-        self.icon = wx.Icon(Bpath("images", "brz.ico"), wx.BITMAP_TYPE_ICO)
+        if os.name == 'posix':
+            self.icon = wx.Icon(Bpath("images", "brz.png"), wx.BITMAP_TYPE_ICO)
+        else:
+            self.icon = wx.Icon(Bpath("images", "brz.ico"), wx.BITMAP_TYPE_ICO)
         self.__init_execute_path()
 
         IDEFrame.__init__(self, parent, debug)


### PR DESCRIPTION
brz.ico does not show up correctly when on a linux system by default.
![Screenshot from 2024-02-26 21-39-29](https://github.com/thiagoralves/OpenPLC_Editor/assets/71559572/52d31eae-880e-4d1e-a29f-7117b6e1ccac)

Added a line to check for linux system, and if so use brz.png.
![Screenshot from 2024-02-26 21-40-54](https://github.com/thiagoralves/OpenPLC_Editor/assets/71559572/c6190d6f-bf3e-42bf-8ca0-36a24048bb19)

Not sure if this is related to desktop environment, seems like an odd error to occur. Input would be appreciated.
