### PR TITLE
Add support for ESP32S3

### DIFF
--- a/editor/arduino/builder.py
+++ b/editor/arduino/builder.py
@@ -113,7 +113,7 @@ def build(st_file, platform, source_file, port, txtCtrl, hals, update_subsystem)
         compiler_logs += runCommand(
             cli_command + ' config remove board_manager.additional_urls \
 https://arduino.esp8266.com/stable/package_esp8266com_index.json \
-https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json \
+https://espressif.github.io/arduino-esp32/package_esp32_index.json \
 https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json \
 https://raw.githubusercontent.com/CONTROLLINO-PLC/CONTROLLINO_Library/master/Boards/package_ControllinoHardware_index.json \
 https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json \
@@ -128,7 +128,7 @@ https://raw.githubusercontent.com/facts-engineering/facts-engineering.github.io/
         compiler_logs += runCommand(
             cli_command + ' config add board_manager.additional_urls \
 https://arduino.esp8266.com/stable/package_esp8266com_index.json \
-https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json \
+https://espressif.github.io/arduino-esp32/package_esp32_index.json \
 https://github.com/stm32duino/BoardManagerFiles/raw/main/package_stmicroelectronics_index.json \
 https://raw.githubusercontent.com/CONTROLLINO-PLC/CONTROLLINO_Library/master/Boards/package_ControllinoHardware_index.json \
 https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json \
@@ -420,15 +420,19 @@ void updateTime()
     compiler_logs += platform
     compiler_logs += '\n'
 
+    extraflags = ''
+    if core == 'esp32:esp32':
+        extraflags = ' -MMD -c'
+
     if os_platform.system() == 'Windows':
-        compilation = subprocess.Popen(['editor\\arduino\\bin\\arduino-cli-w64', 'compile', '-v', '--libraries=editor\\arduino', '--build-property', 'compiler.c.extra_flags="-Ieditor\\arduino\\src\\lib"', '--build-property',
-                                       'compiler.cpp.extra_flags="-Ieditor\\arduino\\src\\lib"', '--export-binaries', '-b', platform, 'editor\\arduino\\examples\\Baremetal\\Baremetal.ino'], creationflags=0x08000000, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        compilation = subprocess.Popen(['editor\\arduino\\bin\\arduino-cli-w64', 'compile', '-v', '--libraries=editor\\arduino', '--build-property', 'compiler.c.extra_flags=-Ieditor\\arduino\\src\\lib' + extraflags, '--build-property',
+                                       'compiler.cpp.extra_flags=-Ieditor\\arduino\\src\\lib' + extraflags, '--export-binaries', '-b', platform, 'editor\\arduino\\examples\\Baremetal\\Baremetal.ino'], creationflags=0x08000000, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     elif os_platform.system() == 'Darwin':
-        compilation = subprocess.Popen(['editor/arduino/bin/arduino-cli-mac', 'compile', '-v', '--libraries=editor/arduino', '--build-property', 'compiler.c.extra_flags="-Ieditor/arduino/src/lib"', '--build-property',
-                                       'compiler.cpp.extra_flags="-Ieditor/arduino/src/lib"', '--export-binaries', '-b', platform, 'editor/arduino/examples/Baremetal/Baremetal.ino'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        compilation = subprocess.Popen(['editor/arduino/bin/arduino-cli-mac', 'compile', '-v', '--libraries=editor/arduino', '--build-property', 'compiler.c.extra_flags=-Ieditor/arduino/src/lib' + extraflags, '--build-property',
+                                       'compiler.cpp.extra_flags=-Ieditor/arduino/src/lib' + extraflags, '--export-binaries', '-b', platform, 'editor/arduino/examples/Baremetal/Baremetal.ino'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     else:
-        compilation = subprocess.Popen(['editor/arduino/bin/arduino-cli-l64', 'compile', '-v', '--libraries=editor/arduino', '--build-property', 'compiler.c.extra_flags="-Ieditor/arduino/src/lib"', '--build-property',
-                                       'compiler.cpp.extra_flags="-Ieditor/arduino/src/lib"', '--export-binaries', '-b', platform, 'editor/arduino/examples/Baremetal/Baremetal.ino'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        compilation = subprocess.Popen(['editor/arduino/bin/arduino-cli-l64', 'compile', '-v', '--libraries=editor/arduino', '--build-property', 'compiler.c.extra_flags=-Ieditor/arduino/src/lib' + extraflags, '--build-property',
+                                       'compiler.cpp.extra_flags=-Ieditor/arduino/src/lib' + extraflags, '--export-binaries', '-b', platform, 'editor/arduino/examples/Baremetal/Baremetal.ino'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = compilation.communicate()
     compiler_logs += stdout.decode('UTF-8', errors='backslashreplace')
     compiler_logs += stderr.decode('UTF-8', errors='backslashreplace')

--- a/editor/arduino/builder.py
+++ b/editor/arduino/builder.py
@@ -167,7 +167,6 @@ arduinomqttclient \
 RP2040_PWM \
 AVR_PWM \
 megaAVR_PWM \
-ESP32_FastPWM \
 SAMD_PWM \
 SAMDUE_PWM \
 Portenta_H7_PWM \

--- a/editor/arduino/examples/Baremetal/hals.json
+++ b/editor/arduino/examples/Baremetal/hals.json
@@ -338,6 +338,22 @@
       "user_dout": "01, 02, 03, 04, 05, 12, 13, 14, 15, 16",
       "user_aout": "25, 26"
     },
+    "ESP32-S3": {
+      "platform": "esp32:esp32:esp32s3",
+      "define": "BOARD_ESP32",
+      "source": "esp32.cpp",
+      "version": "0",
+      "last_update": 0,
+      "core": "esp32:esp32",
+      "default_din": "6, 7, 8, 9",
+      "default_ain": "1, 2, 3, 4",
+      "default_dout": "34, 35",
+      "default_aout": "36, 37",
+      "user_din": "6, 7, 8, 9",
+      "user_ain": "1, 2, 3, 4",
+      "user_dout": "34, 35",
+      "user_aout": "36, 37"
+    },
     "ESP8266 D1-mini": {
       "platform": "esp8266:esp8266:d1_mini",
       "define": "BOARD_ESP8266",

--- a/editor/arduino/src/hal/esp32.cpp
+++ b/editor/arduino/src/hal/esp32.cpp
@@ -4,62 +4,24 @@ extern "C" {
 }
 #include "Arduino.h"
 #include "../examples/Baremetal/defines.h"
+#include "driver/ledc.h"
 
-#include "ESP32_FastPWM.h"
+// OpenPLC HAL for ESP32 boards
+// NOTE: PWM channel == pin number
 
-//OpenPLC HAL for ESP32 boards
-
-/******************PINOUT CONFIGURATION**************************
-Digital In:  17, 18, 19, 21, 22, 23, 27, 32 (%IX0.0 - %IX0.7)
-             33                             (%IX1.0 - %IX1.0)
-Digital Out: 01, 02, 03, 04, 05, 12, 13, 14 (%QX0.0 - %QX0.7)
-             15, 16                         (%QX1.0 - %QX1.1)
-Analog In:   34, 35, 36, 39                 (%IW0 - %IW2)
-Analog Out:  25, 26                         (%QW0 - %QW1)
-*****************************************************************/
-
-//Create the I/O pin masks
+// Create the I/O pin masks (defined within editor GUI when compiling for board)
 uint8_t pinMask_DIN[] = {PINMASK_DIN};
 uint8_t pinMask_AIN[] = {PINMASK_AIN};
 uint8_t pinMask_DOUT[] = {PINMASK_DOUT};
 uint8_t pinMask_AOUT[] = {PINMASK_AOUT};
 
-    #define PWM_DEFAULT_FREQ      490
-
-    #define NUM_OF_PWM_PINS       8 //only 8 pins possible with independent frequency
-
-    #define PWM_CHANNEL_0_PIN     4
-    #define PWM_CHANNEL_1_PIN     13
-    #define PWM_CHANNEL_2_PIN     18
-    #define PWM_CHANNEL_3_PIN     19
-    #define PWM_CHANNEL_4_PIN     21
-    #define PWM_CHANNEL_5_PIN     22
-    #define PWM_CHANNEL_6_PIN     32
-    #define PWM_CHANNEL_7_PIN     33
-
-    #define TIMER_CHANNEL_0       0
-    #define TIMER_CHANNEL_1       2
-    #define TIMER_CHANNEL_2       4
-    #define TIMER_CHANNEL_3       6
-    #define TIMER_CHANNEL_4       8
-    #define TIMER_CHANNEL_5       10
-    #define TIMER_CHANNEL_6       12
-    #define TIMER_CHANNEL_7       14
-
-    #define PWM_RESOLUTION        12 //12-bit
-
-
-    ESP32_FAST_PWM *PWM_Instance[NUM_OF_PWM_PINS];
-
-    const uint8_t pins[] = {PWM_CHANNEL_0_PIN, PWM_CHANNEL_1_PIN, PWM_CHANNEL_2_PIN, PWM_CHANNEL_3_PIN,
-                            PWM_CHANNEL_4_PIN, PWM_CHANNEL_5_PIN, PWM_CHANNEL_6_PIN, PWM_CHANNEL_7_PIN};
-
-    const uint8_t timers[] = {TIMER_CHANNEL_0, TIMER_CHANNEL_1, TIMER_CHANNEL_2, TIMER_CHANNEL_3,
-                              TIMER_CHANNEL_4, TIMER_CHANNEL_5, TIMER_CHANNEL_6, TIMER_CHANNEL_7};
+#define PWM_ANALOG_FREQ       4000 // Frequency to use when emulating analog on boards without a DAC
+#define PWM_RESOLUTION        12 // 12-bit should allow up to 10kHz
+#define PWM_MAX               0xFFF // 12-bit max
 
 extern "C" uint8_t set_hardware_pwm(uint8_t, float, float); //this call is required for the C-based PWM block on the Editor
 
-bool pwm_initialized = false;
+bool pwm_initialized[64] = {false}; // Store which PWM channels have been initialised
 
 void hardwareInit()
 {
@@ -67,12 +29,12 @@ void hardwareInit()
     {
         pinMode(pinMask_DIN[i], INPUT);
     }
-    
+
     for (int i = 0; i < NUM_ANALOG_INPUT; i++)
     {
         pinMode(pinMask_AIN[i], INPUT);
     }
-    
+
     for (int i = 0; i < NUM_DISCRETE_OUTPUT; i++)
     {
         pinMode(pinMask_DOUT[i], OUTPUT);
@@ -81,89 +43,37 @@ void hardwareInit()
     for (int i = 0; i < NUM_ANALOG_OUTPUT; i++)
     {
         pinMode(pinMask_AOUT[i], OUTPUT);
-    }
-}
-
-void init_pwm()
-{
-    // Initialize PWM pins
-    for (int i = 0; i < NUM_OF_PWM_PINS; i++)
-    {
-    PWM_Instance[i] = new ESP32_FAST_PWM(pins[i], PWM_DEFAULT_FREQ, 0, timers[i], PWM_RESOLUTION); //12 bit resolution
-
-        // disable digital in pins if PWM_CONTROLLER block is being used
-        for (int j = 0; j < NUM_DISCRETE_INPUT; j++)
-        {
-            if (pinMask_DIN[j] == pins[i])
-            {
-                pinMask_DIN[j] = 255; //disable pin
-            }
-        }
-
-        // disable digital out pins if PWM_CONTROLLER block is being used
-        for (int j = 0; j < NUM_DISCRETE_OUTPUT; j++)
-        {
-            if (pinMask_DOUT[j] == pins[i])
-            {
-                pinMask_DOUT[j] = 255; //disable pin
-            }
-        }
-
-        // disable analog in pins if PWM_CONTROLLER block is being used	
-        for (int j = 0; j < NUM_ANALOG_INPUT; j++)
-        {
-            if (pinMask_AIN[j] == pins[i])
-            {
-                pinMask_AIN[j] = 255; //disable pin
-            }
-        }
-
-        // disable analog out pins if PWM_CONTROLLER block is being used
-        for (int j = 0; j < NUM_ANALOG_OUTPUT; j++)
-        {
-            if (pinMask_AOUT[j] == pins[i])
-            {
-                pinMask_AOUT[j] = 255; //disable pin
-            }
-        }
+        #if !SOC_DAC_SUPPORTED
+        ledcAttach(pinMask_AOUT[i], PWM_ANALOG_FREQ, PWM_RESOLUTION);
+        #endif
     }
 }
 
 uint8_t set_hardware_pwm(uint8_t ch, float freq, float duty)
 {
-
-    if (pwm_initialized == false)
+    if (!pwm_initialized[ch])
     {
-        init_pwm();
-        pwm_initialized = true;
+        if (!ledcAttach(ch, (uint32_t)freq, PWM_RESOLUTION))
+        {
+            return 0;
+        }
+        pwm_initialized[ch] = true;
     }
 
-
-    if (ch >= NUM_OF_PWM_PINS)
-    {
-        return 0;
-    }
-
-    if (PWM_Instance[ch]->setPWM(pins[ch], freq, duty))
-    {
-        return 1;
-    }
-
-    return 0;
+    ledcWrite(ch, (uint32_t)(duty / 100 * PWM_MAX));
+    return ledcChangeFrequency(ch, (uint32_t)freq, PWM_RESOLUTION);
 }
 
 void updateInputBuffers()
 {
     for (int i = 0; i < NUM_DISCRETE_INPUT; i++)
     {
-        if (bool_input[i/8][i%8] != NULL) 
-            *bool_input[i/8][i%8] = digitalRead(pinMask_DIN[i]);
+        *bool_input[i/8][i%8] = digitalRead(pinMask_DIN[i]);
     }
-    
+
     for (int i = 0; i < NUM_ANALOG_INPUT; i++)
     {
-        if (int_input[i] != NULL)
-            *int_input[i] = (analogRead(pinMask_AIN[i]) * 16);
+        *int_input[i] = (analogRead(pinMask_AIN[i]) * 16);
     }
 }
 
@@ -171,12 +81,15 @@ void updateOutputBuffers()
 {
     for (int i = 0; i < NUM_DISCRETE_OUTPUT; i++)
     {
-        if (bool_output[i/8][i%8] != NULL) 
-            digitalWrite(pinMask_DOUT[i], *bool_output[i/8][i%8]);
+        digitalWrite(pinMask_DOUT[i], *bool_output[i/8][i%8]);
     }
+
     for (int i = 0; i < NUM_ANALOG_OUTPUT; i++)
     {
-        if (int_output[i] != NULL) 
-            dacWrite(pinMask_AOUT[i], (*int_output[i] / 256));
+        #if SOC_DAC_SUPPORTED
+        dacWrite(pinMask_AOUT[i], (*int_output[i] / 256));
+        #else
+        ledcWrite(pinMask_AOUT[i], (*int_output[i] / 16));
+        #endif
     }
 }

--- a/editor/arduino/src/hal/esp32.hal
+++ b/editor/arduino/src/hal/esp32.hal
@@ -4,5 +4,6 @@
 
 ESP32,                    esp32:esp32:esp32, BOARD_ESP32
 ESP32-S2,                 esp32:esp32:esp32s2, BOARD_ESP32
+ESP32-S3,                 esp32:esp32:esp32s3, BOARD_ESP32
 ESP32-C3,                 esp32:esp32:esp32c3, BOARD_ESP32
 ESP32-DOIT DEVKIT V1,     esp32:esp32:esp32doit-devkit-v1, BOARD_ESP32


### PR DESCRIPTION
Starting to try and add support for the ESP32S3. Main issues with this was the board does not have a DAC so PWM has to be used as a crude substitute.

While modifying the ESP32 file I also made the PWM_CONTROLLER implementation more flexible, moving away from FastPWM which seems to be abandoned over to the more standard LEDC.

Would appreciate some help as in order to use the required LEDC channel initiation function, esp32:esp32 core >3.0.0 must be used. I have made an attempt to switch over to the development library sources, but I'm just getting a bunch of undefined reference errors when compiling.

Changes made:
- Remove fastPWM dependency as it seems unmaintained and has issues with duty cycle 0% and 100% (at least on my board). Switch to the LEDC library which is bundled with the ESP32 core.
  - This also allowed for static channel<->pin<->timer mappings in esp32.cpp to be removed. Now the PWM_CONTROLLER block will simply take the board pin as the channel, and will auto assign a timer from those available. **(BREAKING)**
  - Move to dev version of ESP32 core as current version doesn't support auto assigning timers. (see espressif/arduino-esp32#8796)
- Add the ESP32-S3 board
  - Use PWM to emulate analog outputs (at 4khz) on boards without a DAC