### PR TITLE
Add missing dependency for installation on Gentoo Linux.

### DIFF
--- a/install-gentoo.sh
+++ b/install-gentoo.sh
@@ -72,7 +72,7 @@ fi
 
 echo "[INSTALLING PYTHON DEPENDENCIES]"
 # List of Python packages to be installed in VENV
-venv_packages=("zeroconf" "attrdict3")
+venv_packages=("zeroconf" "attrdict3" "pypubsub")
 
 # Function to check if a Python package is installed
 is_python_package_installed() {


### PR DESCRIPTION
Sorry for imcomplete testing. Now the PLC simulator works on Gentoo too. The missing pypubsub module is now properly installed into the venv.