### PR TITLE
Esp32 nullptr dereference

### DIFF
--- a/install-gentoo.sh
+++ b/install-gentoo.sh
@@ -123,6 +123,13 @@ echo "[FINALIZING]"
 # Create launcher script
 if ! echo -e "#!/bin/bash\n\
 cd \"$OPENPLC_DIR\"\n\
+if [ -d \"./new_editor\" ]\n\
+then\n\
+    rm -Rf editor\n\
+    rm -Rf ./matiec/lib\n\
+    mv ./new_editor ./editor\n\
+    mv ./new_lib ./matiec/lib\n\
+fi\n\
 source \"$VENV_DIR/bin/activate\"\n\
 python ./editor/Beremiz.py" > openplc_editor.sh; then
     echo "Failed to create launcher script."

--- a/install-gentoo.sh
+++ b/install-gentoo.sh
@@ -5,6 +5,8 @@ VENV_DIR="$OPENPLC_DIR/.venv"
 
 echo ""
 
+git submodule update --init --recursive "$OPENPLC_DIR"
+
 # Check for Gentoo
 if ! command -v equery &> /dev/null; then
     echo "This script is intended for Gentoo Linux and relies there on 'app-portage/gentoolkit'."

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,8 @@ OPENPLC_DIR="$(dirname "$(readlink -f "$0")")"
 VENV_DIR="$OPENPLC_DIR/.venv"
 
 cd "$OPENPLC_DIR"
+git submodule update --init --recursive "$OPENPLC_DIR"
+
 echo "Installing OpenPLC Editor"
 echo "Please be patient. This may take a couple minutes..."
 echo ""
@@ -43,7 +45,7 @@ fi
 if [ $(uname) == "FreeBSD" ]; then
     # use system packages on FreeBSD
     python3.9 -m venv --system-site-packages "$VENV_DIR"
-    "$VENV_DIR/bin/python" -m pip install --upgrade pip 
+    "$VENV_DIR/bin/python" -m pip install --upgrade pip
     "$VENV_DIR/bin/python" -m pip install zeroconf pypubsub pyro5 attrdict3
 else
     python3.9 -m venv "$VENV_DIR"

--- a/install.sh
+++ b/install.sh
@@ -68,7 +68,7 @@ else
 fi
 
 make -s
-cp ./iec2c ../editor/arduino/bin/
+cp ./iec2c "$OPENPLC_DIR/editor/arduino/bin/"
 echo ""
 echo "[FINALIZING]"
 cd "$OPENPLC_DIR"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-OPENPLC_DIR="$PWD"
+OPENPLC_DIR="$(dirname "$(readlink -f "$0")")"
 VENV_DIR="$OPENPLC_DIR/.venv"
 
+cd "$OPENPLC_DIR"
 echo "Installing OpenPLC Editor"
 echo "Please be patient. This may take a couple minutes..."
 echo ""
@@ -54,7 +55,7 @@ fi
 
 echo ""
 echo "[COMPILING MATIEC]"
-cd matiec
+cd "$OPENPLC_DIR/matiec"
 autoreconf -i
 
 # clang treats this as an error while gcc treats it as a warning
@@ -68,11 +69,10 @@ make -s
 cp ./iec2c ../editor/arduino/bin/
 echo ""
 echo "[FINALIZING]"
-cd ..
+cd "$OPENPLC_DIR"
 
-WORKING_DIR=$(pwd)
 echo -e "#!/bin/bash\n\
-cd \"$WORKING_DIR\"\n\
+cd \"$OPENPLC_DIR\"\n\
 if [ -d \"./new_editor\" ]\n\
 then\n\
     rm -Rf editor\n\
@@ -80,6 +80,7 @@ then\n\
     mv ./new_editor ./editor\n\
     mv ./new_lib ./matiec/lib\n\
 fi\n\
+source \"$VENV_DIR/bin/activate\"\n\
 ./.venv/bin/python3 ./editor/Beremiz.py" > openplc_editor.sh
 chmod +x ./openplc_editor.sh
 
@@ -88,7 +89,7 @@ cd ~/.local/share/applications || exit
 echo -e "[Desktop Entry]\n\
 Name=OpenPLC Editor\n\
 Categories=Development;\n\
-Exec=\"$WORKING_DIR/openplc_editor.sh\"\n\
-Icon=$WORKING_DIR/editor/images/brz.png\n\
+Exec=\"$OPENPLC_DIR/openplc_editor.sh\"\n\
+Icon=$OPENPLC_DIR/editor/images/brz.png\n\
 Type=Application\n\
 Terminal=false" > OpenPLC_Editor.desktop

--- a/update.cmd
+++ b/update.cmd
@@ -3,6 +3,7 @@ set path=%gitdir%\cmd;%path%
 if exist .\new_editor\ rmdir /s /Q new_editor
 if exist .\OpenPLC_Editor\ rmdir /s /Q OpenPLC_Editor
 git clone https://github.com/thiagoralves/OpenPLC_Editor
+git submodule update --init --recursive OpenPLC_Editor
 if exist .\OpenPLC_Editor\editor\ (
   move .\OpenPLC_Editor\editor .\new_editor
   move .\OpenPLC_Editor\matiec\lib .\new_lib


### PR DESCRIPTION
Import the improved editor path to solve the nullptr dereference issue on ESP32 boards.

This PR is based on the `submode-update` due to my limited git skills.