### PR TITLE
Verbose output for wxPython installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ else
     python3.9 -m venv "$VENV_DIR"
     "$VENV_DIR/bin/python" -m pip install --upgrade pip
     "$VENV_DIR/bin/python" -m pip install wheel jinja2 lxml==4.6.2 future matplotlib zeroconf pyserial pypubsub pyro5 attrdict3
-    "$VENV_DIR/bin/python" -m pip install wxPython==4.2.0
+    "$VENV_DIR/bin/python" -m pip install wxPython==4.2.0 -v
 fi
 
 


### PR DESCRIPTION
The installation of wxPython takes a very long time and it may look like the program is stuck. Showing verbose output of pip shows that it is actually doing work.