### PR TITLE
Improved installation script for arch based distros

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,9 +39,25 @@ elif [ -x /usr/sbin/pkg ] && [ $(uname) == "FreeBSD" ]; then
 #Installing dependencies for Arch Linux
 elif [ -x /usr/bin/pacman ]; then
     sudo pacman -Syu --noconfirm
-    sudo pacman -S --noconfirm base-devel yay gtk3 python-pip
-# Installing python3.9 from AUR
-    yay -S --noconfirm python39
+    sudo pacman -S --noconfirm --needed base-devel gtk3 python-pip \
+        autoconf automake bison flex git
+
+    # Check if an AUR helper is available
+    if command -v yay >/dev/null 2>&1; then
+        AUR_HELPER="yay"
+    elif command -v paru >/dev/null 2>&1; then
+        AUR_HELPER="paru"
+    else
+        echo "Installing yay AUR helper..."
+        cd /tmp
+        git clone https://aur.archlinux.org/yay.git
+        cd yay
+        makepkg -si --noconfirm
+        cd "$OPENPLC_DIR"
+        AUR_HELPER="yay"
+    fi
+    # Installing python3.9 from AUR using the detected/installed AUR helper
+    $AUR_HELPER -S --noconfirm python39
 else
     echo "Unsupported linux distro."
     exit 1


### PR DESCRIPTION
I have added the `--needed` flag to the `pacman` install to not reinstall any dependencies that are already present on the system ([docs](https://man.archlinux.org/man/pacman.8.en.html#UPGRADE_OPTIONS_(APPLY_TO_-S_AND_-U))). I also added the dependencies that are installed on other systems but where missing on the `pacman` install.

The script also used yay exclusively, although there are people that use `paru` ([GitHub](https://github.com/Morganamilo/paru)) as a helper for the AUR, where `python3.9` is installed from. The script now detects whether the user has `yay` or `paru` installed, when both are not found, it installs yay.